### PR TITLE
Commands path info in angular example readme

### DIFF
--- a/core/examples/luigi-sample-angular/README.md
+++ b/core/examples/luigi-sample-angular/README.md
@@ -22,7 +22,7 @@ To have this application running, follow these steps:
     lerna bootstrap
     ```
 
-3. Bundle the Luigi core by executing the following in `luigi/core` folder.
+3. Bundle the Luigi core by executing the following in the `luigi/core` folder.
     ```bash
     # Lerna runs the bundle script in every package where the script exists.
 

--- a/core/examples/luigi-sample-angular/README.md
+++ b/core/examples/luigi-sample-angular/README.md
@@ -15,21 +15,21 @@ To have this application running, follow these steps:
     npm install -g lerna
     ```
 
-2. Install dependencies.
+2. Install dependencies. Execute the following command in the root `luigi` folder.
     ```bash
     # The `lerna bootstrap` command executes the Node Package Manager (NPM) installation and links cross-dependencies.
 
     lerna bootstrap
     ```
 
-3. Bundle the Luigi core.
+3. Bundle the Luigi core by executing the following in `luigi/core` folder.
     ```bash
     # Lerna runs the bundle script in every package where the script exists.
 
     lerna run bundle
     ```
 
-4. Start the example application.
+4. Start the example application from `luigi/core/examples/luigi-sample-angular` folder.
     ```bash
     npm start
     ```

--- a/core/examples/luigi-sample-angular/README.md
+++ b/core/examples/luigi-sample-angular/README.md
@@ -29,7 +29,7 @@ To have this application running, follow these steps:
     lerna run bundle
     ```
 
-4. Start the example application from `luigi/core/examples/luigi-sample-angular` folder.
+4. Start the example application from the `luigi/core/examples/luigi-sample-angular` folder.
     ```bash
     npm start
     ```


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Added info about commands path to _luigi-sample-angular_ readme

**Related issue(s)**
Resolves #106 

