### PR TITLE
fix OAuth 2.0 logout timeout

### DIFF
--- a/core/src/providers/auth/oAuth2ImplicitGrant.js
+++ b/core/src/providers/auth/oAuth2ImplicitGrant.js
@@ -82,7 +82,7 @@ export class oAuth2ImplicitGrant {
 
   setTokenExpirationAction() {
     const expirationCheckInterval = 5000;
-    const logoutBeforeExpirationTime = 3540000;
+    const logoutBeforeExpirationTime = 60000;
 
     setInterval(() => {
       let authData;


### PR DESCRIPTION
**Description**

Fixes logout timeout for mock OAuth 2.0 from 1 minute to 59 minutes.