### PR TITLE
viewUrl should not be mandatory in dynamic node

### DIFF
--- a/core/examples/luigi-sample-angular/src/app/app.component.ts
+++ b/core/examples/luigi-sample-angular/src/app/app.component.ts
@@ -14,7 +14,7 @@ export class AppComponent implements OnInit {
   public luigiClient: LuigiClient = LuigiClient;
   public title: string = 'app';
 
-  constructor(private luigiService: LuigiContextService) {}
+  constructor(private luigiService: LuigiContextService) { }
 
   ngOnInit() {
     this.luigiClient.addInitListener(context =>

--- a/core/src/navigation/services/navigation.js
+++ b/core/src/navigation/services/navigation.js
@@ -189,7 +189,11 @@ export const findMatchingNode = (urlPathElement, nodes) => {
         node.pathParam.key,
         urlPathElement
       );
-      node.viewUrl = node.viewUrl.replace(node.pathParam.key, urlPathElement);
+
+      if (node.viewUrl) {
+        node.viewUrl = node.viewUrl.replace(node.pathParam.key, urlPathElement);
+      }
+
       if (node.context) {
         Object.entries(node.context).map(entry => {
           const dynKey = entry[1];


### PR DESCRIPTION
Added bugfix for error occured when not having defined a viewUrl within a dynamic node.