### PR TITLE
Allow async defaultChildNode

### DIFF
--- a/core/examples/luigi-sample-angular/src/app/app.component.ts
+++ b/core/examples/luigi-sample-angular/src/app/app.component.ts
@@ -14,7 +14,7 @@ export class AppComponent implements OnInit {
   public luigiClient: LuigiClient = LuigiClient;
   public title: string = 'app';
 
-  constructor(private luigiService: LuigiContextService) {}
+  constructor(private luigiService: LuigiContextService) { }
 
   ngOnInit() {
     this.luigiClient.addInitListener(context =>

--- a/core/src/services/routing.js
+++ b/core/src/services/routing.js
@@ -8,6 +8,7 @@ import {
   isIE,
   getConfigValueFromObject
 } from '../utilities/helpers';
+import { getConfigValueFromObjectAsync } from '../utilities/async-helpers';
 
 const iframeNavFallbackTimeout = 2000;
 let timeoutHandle;
@@ -18,18 +19,19 @@ const getLastNodeObject = pathData => {
   return lastElement ? lastElement : {};
 };
 
-const getDefaultChildNode = function(pathData) {
+const getDefaultChildNode = async function(pathData) {
   const lastElement =
     pathData.navigationPath[pathData.navigationPath.length - 1];
 
-  const pathExists = lastElement.children.find(
+  const children = await getConfigValueFromObjectAsync(lastElement, 'children');
+  const pathExists = children.find(
     childNode => childNode.pathSegment === lastElement.defaultChildNode
   );
 
   if (lastElement.defaultChildNode && pathExists) {
     return lastElement.defaultChildNode;
-  } else if (lastElement.children && lastElement.children.length > 0) {
-    return lastElement.children[0].pathSegment;
+  } else if (children && children.length > 0) {
+    return children[0].pathSegment;
   } else {
     return '';
   }
@@ -308,7 +310,7 @@ export const handleRouteChange = async (path, component, node, config) => {
       const routeExists = isExistingRoute(path, pathData);
 
       if (routeExists) {
-        const defaultChildNode = getDefaultChildNode(pathData);
+        const defaultChildNode = await getDefaultChildNode(pathData);
         navigateTo(`${pathUrl ? `/${pathUrl}` : ''}/${defaultChildNode}`);
       } else {
         const alert = {

--- a/core/test/services/routing.spec.js
+++ b/core/test/services/routing.spec.js
@@ -789,24 +789,52 @@ describe('Routing', () => {
       };
     };
 
-    it('should return first child if no defaultChildNode is set', () => {
+    it('should return first child if no defaultChildNode is set', async () => {
       let pathData = getPathData();
 
-      assert.equal(getDefaultChildNode(pathData), 'stakeholders');
+      assert.equal(await getDefaultChildNode(pathData), 'stakeholders');
     });
 
-    it('should return child with pathSegment equal to defaultChildNode', () => {
+    it('should return child with pathSegment equal to defaultChildNode', async () => {
       let pathData = getPathData();
       pathData.navigationPath[1].defaultChildNode = 'customers';
 
-      assert.equal(getDefaultChildNode(pathData), 'customers');
+      assert.equal(await getDefaultChildNode(pathData), 'customers');
     });
 
-    it('should return first child if given defaultChildNode does not exist', () => {
+    it('should return first child if given defaultChildNode does not exist', async () => {
       const pathData = getPathData();
       pathData.navigationPath[1].defaultChildNode = 'NOSUCHPATH';
 
-      assert.equal(getDefaultChildNode(pathData), 'stakeholders');
+      assert.equal(await getDefaultChildNode(pathData), 'stakeholders');
+    });
+
+    it('should return first child asynchronous if no defaultChildNode is set', async () => {
+      let pathData = {
+        navigationPath: [
+          {
+            // DOESN'T MATTER
+          },
+          {
+            pathSegment: 'groups',
+            children: () =>
+              Promise.resolve([
+                {
+                  pathSegment: 'stakeholders',
+                  viewUrl:
+                    '/sampleapp.html#/projects/1/users/groups/stakeholders'
+                },
+                {
+                  pathSegment: 'customers',
+                  viewUrl: '/sampleapp.html#/projects/1/users/groups/customers'
+                }
+              ])
+          }
+        ],
+        context: {}
+      };
+
+      assert.equal(await getDefaultChildNode(pathData), 'stakeholders');
     });
   });
 });


### PR DESCRIPTION
defaultChildNode did not work if children were provided as function or promise, refactored to allow all input variants.