### PR TITLE
Increase oidc client loading timeout

### DIFF
--- a/core/src/providers/auth/openIdConnect.js
+++ b/core/src/providers/auth/openIdConnect.js
@@ -26,7 +26,7 @@ export class openIdConnect {
 
     this.settings = mergedSettings;
 
-    return AsyncHelpers.waitForKeyExistency(window, 'Oidc').then(res => {
+    return AsyncHelpers.waitForKeyExistency(window, 'Oidc', 60000).then(res => {
       this.client = new Oidc.UserManager(this.settings);
 
       this.client.events.addUserLoaded(authenticatedUser => {

--- a/core/src/utilities/helpers/async-helpers.js
+++ b/core/src/utilities/helpers/async-helpers.js
@@ -3,7 +3,7 @@ import * as GenericHelpers from './generic-helpers.js';
 
 const handles = {};
 
-export const keyExistencyTimeout = 20000;
+export const keyExistencyTimeout = 60000;
 export const keyExistencyCheckInterval = 50;
 
 export const waitForKeyExistency = (

--- a/core/src/utilities/helpers/async-helpers.js
+++ b/core/src/utilities/helpers/async-helpers.js
@@ -3,7 +3,7 @@ import * as GenericHelpers from './generic-helpers.js';
 
 const handles = {};
 
-export const keyExistencyTimeout = 60000;
+export const keyExistencyTimeout = 20000;
 export const keyExistencyCheckInterval = 50;
 
 export const waitForKeyExistency = (


### PR DESCRIPTION
**Description**

Increased timeout for async loading of oidc library.
Why 60 sec? To match [default navigation timeout in ui tests](https://github.com/kyma-project/console/blob/master/tests/ui-tests/config.js#L24) that sometimes fail on slow network conditions
