### PR TITLE
Fix iframe top position

### DIFF
--- a/core/src/App.html
+++ b/core/src/App.html
@@ -456,7 +456,7 @@
 </script>
 
 <style type="text/scss">
-  $topNavHeight: 50px;
+  $topNavHeight: 48px;
   $leftNavWidth: 320px;
   :global(html) {
     box-sizing: border-box;

--- a/core/src/navigation/LeftNav.html
+++ b/core/src/navigation/LeftNav.html
@@ -171,12 +171,13 @@
 </script>
 
 <style type="text/scss">
+  $topNavHeight: 48px;
   a {
     cursor: pointer;
   }
   .fd-app__sidebar {
     position: fixed;
-    top: 48px;
+    top: $topNavHeight;
     left: 0;
     width: 320px;
     bottom: 0;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix iframe top position (was 2 pixels below it should)

**How to reproduce it**
Please add this line to _core/src/Backdrop.html_, together with the other styles for _.fd_overlay_: `background: rgba(74,80,92, .1);`. The bug is evident only by using a [different color](https://user-images.githubusercontent.com/8238188/51603604-8a2f4b00-1f0a-11e9-86d9-7314433b836f.png)
 for the Luigi part backdrop. 

