### PR TITLE
Remove repeating code in unit tests

### DIFF
--- a/core/test/services/iframe.spec.js
+++ b/core/test/services/iframe.spec.js
@@ -7,6 +7,7 @@ import { LuigiConfig } from '../../src/services/config';
 
 describe('Iframe', () => {
   let component;
+  let node;
 
   beforeEach(() => {
     let lastObj = {};
@@ -18,7 +19,38 @@ describe('Iframe', () => {
     };
 
     sinon.stub(LuigiConfig, 'getConfigValue');
+
+    node = {
+      children: [
+        {
+          style: {
+            display: null
+          },
+          id: 1
+        },
+        {
+          style: {
+            display: null
+          },
+          id: 2
+        },
+        {
+          style: {
+            display: null
+          },
+          id: 3
+        }
+      ],
+      removeChild: child => {
+        node.children.forEach((c, i) => {
+          if (c === child) {
+            node.children.splice(i, 1);
+          }
+        });
+      }
+    };
   });
+
   afterEach(() => {
     if (document.createElement.restore) {
       document.createElement.restore();
@@ -28,84 +60,23 @@ describe('Iframe', () => {
 
   describe('setActiveIframeToPrevious', () => {
     it('standard', () => {
-      let node = {
-        children: [
-          {
-            style: {
-              display: null
-            }
-          }
-        ],
-        removeChild: child => {
-          node.children.forEach((c, i) => {
-            if (c === child) {
-              node.children.splice(i, 1);
-            }
-          });
-        }
-      };
-
       Iframe.setActiveIframeToPrevious(node);
 
-      assert.equal(node.children.length, 1);
+      assert.equal(node.children.length, 2);
       assert.equal(node.children[0].style.display, 'block');
     });
 
     it('goBack', () => {
-      let node = {
-        children: [
-          {
-            style: {
-              display: null
-            },
-            id: 1
-          },
-          {
-            style: {
-              display: null
-            },
-            id: 2
-          }
-        ],
-        removeChild: child => {
-          node.children.forEach((c, i) => {
-            if (c === child) {
-              node.children.splice(i, 1);
-            }
-          });
-        }
-      };
-
       Iframe.setActiveIframeToPrevious(node);
 
-      assert.equal(node.children.length, 1);
+      assert.equal(node.children.length, 2);
       assert.equal(node.children[0].style.display, 'block');
       assert.equal(node.children[0].id, 2);
     });
   });
 
   it('removeInactiveIframes', () => {
-    let node = {
-      removeChild: sinon.spy(),
-      children: [
-        {
-          style: {
-            display: null
-          }
-        },
-        {
-          style: {
-            display: null
-          }
-        },
-        {
-          style: {
-            display: null
-          }
-        }
-      ]
-    };
-
+    node.removeChild = sinon.spy();
     Iframe.removeInactiveIframes(node);
 
     assert.equal(node.removeChild.callCount, 2);

--- a/core/test/services/iframe.spec.js
+++ b/core/test/services/iframe.spec.js
@@ -6,18 +6,9 @@ import { afterEach } from 'mocha';
 import { LuigiConfig } from '../../src/services/config';
 
 describe('Iframe', () => {
-  let component;
   let node;
 
   beforeEach(() => {
-    let lastObj = {};
-    component = {
-      set: obj => {
-        Object.assign(lastObj, obj);
-      },
-      get: () => lastObj
-    };
-
     sinon.stub(LuigiConfig, 'getConfigValue');
 
     node = {

--- a/core/test/services/routing.spec.js
+++ b/core/test/services/routing.spec.js
@@ -155,6 +155,7 @@ describe('Routing', () => {
     beforeEach(() => {
       window.Luigi = { config: currentLuigiConfig };
       currentLuigiConfig = Object.assign({}, sampleLuigiConfig);
+      LuigiConfig.config = currentLuigiConfig;
       config = {
         iframe: null,
         builderCompatibilityMode: false,

--- a/core/test/services/routing.spec.js
+++ b/core/test/services/routing.spec.js
@@ -10,6 +10,7 @@ import { LuigiConfig } from '../../src/services/config';
 describe('Routing', () => {
   let component;
   beforeEach(() => {
+    window.dispatchEvent = sinon.spy();
     let lastObj = {};
     component = {
       set: obj => {
@@ -29,10 +30,6 @@ describe('Routing', () => {
   });
 
   describe('buildFromRelativePath', () => {
-    beforeEach(() => {
-      window.dispatchEvent = sinon.spy();
-    });
-
     const nodeWithParent = {
       link: 'child-node',
       parent: {
@@ -154,6 +151,8 @@ describe('Routing', () => {
 
     beforeEach(() => {
       window.Luigi = { config: currentLuigiConfig };
+      global.window = window;
+      global.document = document;
       currentLuigiConfig = Object.assign({}, sampleLuigiConfig);
       LuigiConfig.config = currentLuigiConfig;
       config = {
@@ -216,8 +215,6 @@ describe('Routing', () => {
       // given
       const path = '#/projects';
       const expectedViewUrl = '/aaa.html';
-      global.window = window;
-      global.document = document;
 
       let savedObj = {};
       const componentSaved = {
@@ -271,7 +268,6 @@ describe('Routing', () => {
       const path = '#/projects/a1?~param1=tets';
       const expectedViewUrl = '{context.varA1}/a1.html#p={nodeParams.param1}';
       const expectedProcessedViewUrl = 'maskopatol/a1.html#p=tets';
-      global.document = document;
 
       // when
       const iframeMock = { src: null };
@@ -297,8 +293,6 @@ describe('Routing', () => {
       const path = '#/projects/a2?~param1=tets';
       const expectedViewUrl = '{context.varA2}/a2.html#p={nodeParams.param2}';
       const expectedProcessedViewUrl = '/a2.html#p=';
-      global.window = window;
-      global.document = document;
 
       // when
       const iframeMock = { src: null };
@@ -323,8 +317,6 @@ describe('Routing', () => {
       // given
       const path = '#/projects/categories/cat1';
       const expectedViewUrl = 'cats/cat1#details';
-      global.window = window;
-      global.document = document;
 
       // when
       const iframeMock = { src: null };
@@ -348,8 +340,6 @@ describe('Routing', () => {
       // given
       const path = '#/projects/categories/cat1/sub23';
       const expectedViewUrl = 'cats/cat1/sub23';
-      global.window = window;
-      global.document = document;
 
       // when
       const iframeMock = { src: null };
@@ -373,7 +363,6 @@ describe('Routing', () => {
       // given
       const path = '#/projects/teams';
       const expectedPath = '/projects/teams/t2';
-      global.window = window;
       const component = {
         shouldShowUnsavedChangesModal: () => false
       };
@@ -396,7 +385,6 @@ describe('Routing', () => {
     it("should set component's 'hideSideNav' property", async () => {
       // given
       const path = '#/projects';
-      global.window = window;
 
       //when
       const node = { insertBefore: sinon.spy() };
@@ -411,10 +399,6 @@ describe('Routing', () => {
   });
 
   describe('handleRouteClick', () => {
-    beforeEach(() => {
-      window.dispatchEvent = sinon.spy();
-    });
-
     const nodeWithParent = {
       pathSegment: 'project-one',
       parent: {

--- a/core/test/utilities/helpers/routing-helpers.spec.js
+++ b/core/test/utilities/helpers/routing-helpers.spec.js
@@ -5,38 +5,30 @@ import * as RoutingHelpers from '../../../src/utilities/helpers/routing-helpers'
 
 describe('Routing-helpers', () => {
   describe('substituteDynamicParamsInObject', () => {
-    it('substitutes an object', () => {
-      const input = {
+    let input, paramMap, expectedOutput;
+    beforeEach(() => {
+      input = {
         key1: 'something',
         key2: ':group'
       };
-      const paramMap = {
+      paramMap = {
         group: 'mygroup'
       };
 
-      const expectedOutput = {
+      expectedOutput = {
         key1: 'something',
         key2: 'mygroup'
       };
+    });
 
+    it('substitutes an object', () => {
       expect(
         RoutingHelpers.substituteDynamicParamsInObject(input, paramMap)
       ).to.deep.equal(expectedOutput);
       expect(input.key2).to.equal(':group');
     });
     it('substitutes an object using custom prefix', () => {
-      const input = {
-        key1: 'something',
-        key2: '#group'
-      };
-      const paramMap = {
-        group: 'mygroup'
-      };
-
-      const expectedOutput = {
-        key1: 'something',
-        key2: 'mygroup'
-      };
+      input.key2 = '#group';
 
       expect(
         RoutingHelpers.substituteDynamicParamsInObject(input, paramMap, '#')
@@ -46,27 +38,30 @@ describe('Routing-helpers', () => {
   });
 
   describe('defaultChildNodes', () => {
-    const mockPathData = {
-      navigationPath: [
-        {
-          // DOESN'T MATTER
-        },
-        {
-          pathSegment: 'groups',
-          children: [
-            {
-              pathSegment: 'stakeholders',
-              viewUrl: '/sampleapp.html#/projects/1/users/groups/stakeholders'
-            },
-            {
-              pathSegment: 'customers',
-              viewUrl: '/sampleapp.html#/projects/1/users/groups/customers'
-            }
-          ]
-        }
-      ],
-      context: {}
-    };
+    let mockPathData;
+    beforeEach(() => {
+      mockPathData = {
+        navigationPath: [
+          {
+            // DOESN'T MATTER
+          },
+          {
+            pathSegment: 'groups',
+            children: [
+              {
+                pathSegment: 'stakeholders',
+                viewUrl: '/sampleapp.html#/projects/1/users/groups/stakeholders'
+              },
+              {
+                pathSegment: 'customers',
+                viewUrl: '/sampleapp.html#/projects/1/users/groups/customers'
+              }
+            ]
+          }
+        ],
+        context: {}
+      };
+    });
 
     it('should return first child if no defaultChildNode is set', async () => {
       assert.equal(
@@ -76,118 +71,94 @@ describe('Routing-helpers', () => {
     });
 
     it('should return child with pathSegment equal to defaultChildNode', async () => {
-      let pathData = Object.assign(mockPathData);
-      pathData.navigationPath[1].defaultChildNode = 'customers';
+      mockPathData.navigationPath[1].defaultChildNode = 'customers';
 
       assert.equal(
-        await RoutingHelpers.getDefaultChildNode(pathData),
+        await RoutingHelpers.getDefaultChildNode(mockPathData),
         'customers'
       );
     });
 
     it('should return first child if given defaultChildNode does not exist', async () => {
-      let pathData = Object.assign(mockPathData);
-      pathData.navigationPath[1].defaultChildNode = 'NOSUCHPATH';
+      mockPathData.navigationPath[1].defaultChildNode = 'NOSUCHPATH';
 
       assert.equal(
-        await RoutingHelpers.getDefaultChildNode(pathData),
+        await RoutingHelpers.getDefaultChildNode(mockPathData),
         'stakeholders'
       );
     });
 
     it('should return first child asynchronous if no defaultChildNode is set', async () => {
-      const pathData = {
-        navigationPath: [
-          {
-            // DOESN'T MATTER
-          },
-          {
-            pathSegment: 'groups',
-            children: () =>
-              Promise.resolve([
-                {
-                  pathSegment: 'stakeholders',
-                  viewUrl:
-                    '/sampleapp.html#/projects/1/users/groups/stakeholders'
-                },
-                {
-                  pathSegment: 'customers',
-                  viewUrl: '/sampleapp.html#/projects/1/users/groups/customers'
-                }
-              ])
-          }
-        ],
-        context: {}
-      };
-
       assert.equal(
-        await RoutingHelpers.getDefaultChildNode(pathData),
+        await RoutingHelpers.getDefaultChildNode(mockPathData),
         'stakeholders'
       );
     });
 
     it('should return first child that has viewUrl defined', async () => {
-      let pathData = {
-        navigationPath: [
-          {
-            // DOESN'T MATTER
-          },
-          {
-            pathSegment: 'myPath',
-            children: [
-              {
-                pathSegment: 'home',
+      mockPathData.navigationPath = [
+        {
+          // DOESN'T MATTER
+        },
+        {
+          pathSegment: 'myPath',
+          children: [
+            {
+              pathSegment: 'home',
 
-                label: 'go back'
-              },
-              {
-                pathSegment: 'maskopatol',
-                label: 'still no viewUrl'
-              },
-              {
-                pathSegment: 'child',
-                label: 'This should be the default child',
-                viewUrl: '/myApp.html#/default-child'
-              }
-            ]
-          }
-        ],
-        context: {}
-      };
+              label: 'go back'
+            },
+            {
+              pathSegment: 'maskopatol',
+              label: 'still no viewUrl'
+            },
+            {
+              pathSegment: 'child',
+              label: 'This should be the default child',
+              viewUrl: '/sampleapp.html#/myPath/child'
+            }
+          ]
+        }
+      ];
+
+      assert.equal(
+        await RoutingHelpers.getDefaultChildNode(mockPathData),
+        'child'
+      );
     });
 
     it('should return first child that has externalLink.url defined', async () => {
-      let pathData = {
-        navigationPath: [
-          {
-            // DOESN'T MATTER
-          },
-          {
-            pathSegment: 'myPath',
-            children: [
-              {
-                pathSegment: 'home',
+      mockPathData.navigationPath = [
+        {
+          // DOESN'T MATTER
+        },
+        {
+          pathSegment: 'myPath',
+          children: [
+            {
+              pathSegment: 'home',
 
-                label: 'go back'
-              },
-              {
-                pathSegment: 'maskopatol',
-                label: 'still no viewUrl'
-              },
-              {
-                pathSegment: 'child',
-                label: 'This should be the default child',
-                externalLink: {
-                  url: 'https://google.com'
-                }
+              label: 'go back'
+            },
+            {
+              pathSegment: 'maskopatol',
+              label: 'still no viewUrl'
+            },
+            {
+              pathSegment: 'child',
+              label: 'This should be the default child',
+              externalLink: {
+                url: 'https://google.com'
               }
-            ]
-          }
-        ],
-        context: {}
-      };
+            }
+          ]
+        }
+      ];
 
-      assert.equal(await RoutingHelpers.getDefaultChildNode(pathData), 'child');
+      assert.equal(
+        await RoutingHelpers.getDefaultChildNode(mockPathData),
+        'child'
+      );
     });
   });
 });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
- [x] Number of passing tests unchanged
- [x] Number of failing tests unchanged (still 0)

Changes proposed in this pull request:

- `routing.spec.js` line number reduced from 712 to 555 with some empty lines still kept for readability
- Few other test files also "compressed", mostly by extracting repeating parts to `beforeEach()` hook
- Some files are untouched as there were nothing to improve
- Repair one test that didn't have any `expect` (nothing was tested)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
