### PR TITLE
remove unnecessary styles

### DIFF
--- a/core/examples/luigi-sample-angular/src/styles.css
+++ b/core/examples/luigi-sample-angular/src/styles.css
@@ -1,8 +1,5 @@
-
 body {
   padding: 0;
-  margin: 0;
-  position: absolute;
 }
 
 .fd-panel {


### PR DESCRIPTION
Changes proposed in this pull request:

- make the content width as 100% by removing  unnecessary styles
<img width="948" alt="luigi issue" src="https://user-images.githubusercontent.com/46446373/55954090-10337600-5c5e-11e9-8449-a6691a077ecf.png">
